### PR TITLE
Scene clearcolor

### DIFF
--- a/src/ReactBabylonJSHostConfig.ts
+++ b/src/ReactBabylonJSHostConfig.ts
@@ -67,9 +67,17 @@ export const applyUpdateToInstance = (hostInstance: any, update: PropertyUpdate,
         target[update.propertyName] = update.value // ie: undefined/null?
       }
       break
-    case "BABYLON.Color3": // merge this switch with BABYLON.Vector3, Color4, etc.  The copyFrom BABYLON types.
+    case "BABYLON.Color3":
+    case "BABYLON.Color4": // merge this switch with BABYLON.Vector3, Color4, etc.  The copyFrom BABYLON types.
       if (target[update.propertyName]) {
-        ;(target[update.propertyName] as BABYLON.Color3).copyFrom(update.value)
+        switch (update.type) {
+          case "BABYLON.Color3":
+            ;(target[update.propertyName] as BABYLON.Color3).copyFrom(update.value)
+            break
+          case "BABYLON.Color4":
+            ;(target[update.propertyName] as BABYLON.Color4).copyFrom(update.value)
+            break
+        }
       } else if (update.value) {
         target[update.propertyName] = update.value.clone()
       } else {

--- a/src/generatedCode.ts
+++ b/src/generatedCode.ts
@@ -16787,7 +16787,14 @@ export class FiberScenePropsHandler implements PropsHandler<BABYLON.Scene, Fiber
             });
         }
         // TODO: type: BABYLON.Camera property (not coded) BABYLON.Scene.cameraToUseForPointers.
-        // TODO: type: BABYLON.Color4 property (not coded) BABYLON.Scene.clearColor.
+        // BABYLON.Scene.clearColor of BABYLON.Color4 uses object equals to find diffs:
+        if (newProps.clearColor && (!oldProps.clearColor || !oldProps.clearColor.equals(newProps.clearColor))) {
+            updates.push({
+                propertyName: 'clearColor',
+                value: newProps.clearColor,
+                type: 'BABYLON.Color4'
+            });
+        }
         // TODO: type: BABYLON.Plane property (not coded) BABYLON.Scene.clipPlane.
         // TODO: type: BABYLON.Plane property (not coded) BABYLON.Scene.clipPlane2.
         // TODO: type: BABYLON.Plane property (not coded) BABYLON.Scene.clipPlane3.


### PR DESCRIPTION
Fix to allow setting of a scene's clearColor propery

Example:

```jsx
<Engine antialias={true} adaptToDeviceRatio={true} canvasId="sample-canvas">
    <Scene clearColor={new Color4(0, 0, 0, 0.3)}>
      <ArcRotateCamera name="arc" target={new Vector3(0, 1, 0)} minZ={0.001} alpha={-Math.PI / 2} beta={(0.5 + (Math.PI / 4))} radius={2} />
      <HemisphericLight name="light1" intensity={0.9} direction={Vector3.Up()} />
      <Box name="box" size={.5} position={new Vector3(0, 1, 0)}>
        <SingleAxisRotateMeshBehavior rpm={2} axis={Axis.Y} />
        <StandardMaterial name="mat1" diffuseColor={Color3.Yellow()} specularColor={Color3.Black()} />
      </Box>
      <Ground name="ground1" diffuseColor={Color3.Green()} width={6} height={6} subdivisions={2}>
        <StandardMaterial name="mat1" diffuseColor={Color3.Green()} specularColor={Color3.Black()} />
      </Ground>
    </Scene>
  </Engine>
```
![screenshot from 2019-01-26 00-41-38](https://user-images.githubusercontent.com/7163415/51780412-1e193680-2106-11e9-8c7b-cb68c8826862.png)
