### PR TITLE
Hooks for context

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ const DemoComponent = ({ scene, engine, canvas }} => {
 export default withBabylonJS(withScene(DemoComponent))
 ```
 
-### direct consmuer
+### direct Consmuer
 
 ```jsx
 import { WithSceneContext } from 'react-babylonjs'
@@ -322,7 +322,8 @@ const DemoComponent = ({ scene }} => {
     <div>See console</div>
   )
 }
-export default withBabylonJS(withScene(DemoComponent))
+
+export default () => (<WithSceneContext>{DemoComponent}</WithSceneContext>)
 ```
 
 ## Major Release History

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ const App: React.FC = () => {
 import { useBabylonEngine, useBabylonCanvas, useBabylonScene } from 'react-react-babylonjs'
 
 // later inside a functional component:
-const engine = useBabylonEngine{}
+const engine = useBabylonEngine()
 const canvas = useBabylonCanvas()
 const scene = useBabylonScene()
 ````

--- a/README.md
+++ b/README.md
@@ -269,16 +269,61 @@ const App: React.FC = () => {
 }
 ```
 
+## Using context
+
+If you need to do something fancy with `scene`, `canvas`, or `engine`, there are a few ways:
+
+### react hooks
+
 ```jsx
 // use Hooks to get engine/canvas/scene 
-import { useBabylonEngine, useBabylonCanvas, useBabylonScene } from 'react-react-babylonjs'
+import { useBabylonEngine, useBabylonCanvas, useBabylonScene } from 'react-babylonjs'
 
 // later inside a functional component:
-const engine = useBabylonEngine()
-const canvas = useBabylonCanvas()
-const scene = useBabylonScene()
+
+export default () => {
+  const engine = useBabylonEngine()
+  const canvas = useBabylonCanvas()
+  const scene = useBabylonScene()
+  console.log({ engine, canvas, scene })
+  
+  return (
+    <div>See console</div>
+  )
+}
+
 ````
 
+### HOC
+
+```jsx
+import { withBabylonJS, withScene } from 'react-babylonjs'
+
+const DemoComponent = ({ scene, engine, canvas }} => {
+  console.log({ scene, engine, canvas })
+  return (
+    <div>See console</div>
+  )
+}
+
+export default withBabylonJS(withScene(DemoComponent))
+```
+
+### direct consmuer
+
+```jsx
+import { WithSceneContext } from 'react-babylonjs'
+
+const DemoComponent = ({ scene }} => {
+  const engine = scene.getEngine()
+  const canvas = engine.getCanvas()
+  console.log({ scene, engine, canvas })
+  return (
+    <div>See console</div>
+  )
+}
+export default withBabylonJS(withScene(DemoComponent))
+```
 
 ## Major Release History
 > v1.0.0 (2018-11-29) - Add code generation, HoC, context provider

--- a/README.md
+++ b/README.md
@@ -264,10 +264,21 @@ const App: React.FC = () => {
         </ground>
         <vrExperienceHelper webVROptions={{ createDeviceOrientationCamera: false }} enableInteractions={true} />
       </Scene>
-    </EngineWithContext>
+    </Engine>
   );
 }
 ```
+
+```jsx
+// use Hooks to get engine/canvas/scene 
+import { useBabylonEngine, useBabylonCanvas, useBabylonScene } from 'react-react-babylonjs'
+
+// later inside a functional component:
+const engine = useBabylonEngine{}
+const canvas = useBabylonCanvas()
+const scene = useBabylonScene()
+````
+
 
 ## Major Release History
 > v1.0.0 (2018-11-29) - Add code generation, HoC, context provider

--- a/src/Engine.tsx
+++ b/src/Engine.tsx
@@ -1,4 +1,4 @@
-import React, { createContext } from 'react'
+import React, { createContext, useContext } from 'react'
 import { Nullable, Engine as BabylonJSEngine, /*ThinEngine,*/ EngineOptions} from '@babylonjs/core'
 
 
@@ -33,6 +33,9 @@ export function withBabylonJS<
     );
   };
 }
+
+export const useBabylonEngine = () => useContext(BabylonJSContext).engine
+export const useBabylonCanvas = () => useContext(BabylonJSContext).canvas
 
 type EngineProps = {
   babylonJSContext: WithBabylonJSContext,

--- a/src/Scene.tsx
+++ b/src/Scene.tsx
@@ -5,7 +5,7 @@
  * LICENSE.txt file in the root directory of this source tree.
  */
 
-import React, { createContext } from 'react';
+import React, { createContext, useContext } from 'react';
 import ReactReconciler from "react-reconciler";
 
 import { WithBabylonJSContext, withBabylonJS } from './Engine';
@@ -34,6 +34,9 @@ export const SceneContext = createContext<WithSceneContext>({
   canvas: null,
   scene: null
 })
+
+
+export const useBabylonScene = () => useContext(SceneContext).scene
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 

--- a/src/react-babylonjs.ts
+++ b/src/react-babylonjs.ts
@@ -2,7 +2,7 @@ export * from "./generatedCode"
 export * from "./generatedProps"
 export * from "./customComponents" // TODO: Except for Skybox - these should not be exported.  they are internal.
 
-export { default as Engine, withBabylonJS } from "./Engine"
-export { default as Scene, withScene, WithSceneContext, SceneEventArgs } from "./Scene"
+export { default as Engine, withBabylonJS, useBabylonEngine, useBabylonCanvas } from "./Engine"
+export { default as Scene, withScene, WithSceneContext, SceneEventArgs, useBabylonScene } from "./Scene"
 
 export { HostWithEvents, Model } from "./customHosts"


### PR DESCRIPTION
This adds context hooks for #28 

Feel free to write it differently, as I am not super comfy with typescript, so I just did it how I would, in ES6.

I also found a typo in the README, when I was adding docs for hooks.

### usage

```js
import { useBabylonEngine, useBabylonCanvas, useBabylonScene } from 'react-react-babylonjs'

// later inside a functional component:
const engine = useBabylonEngine()
const canvas = useBabylonCanvas()
const scene = useBabylonScene()
```