### PR TITLE
Add the size props to Skybox for custom size

### DIFF
--- a/src/customComponents/Skybox.ts
+++ b/src/customComponents/Skybox.ts
@@ -4,10 +4,11 @@ import {CubeTexture, Texture} from "@babylonjs/core/Materials/Textures"
 interface SkyboxProps {
   // babylonJSContext: PropTypes.any, // To get scene/engine as props via Context API HOC withBabylonJS(Component).
   rootUrl: string
+  size?: number
 }
 
 const Skybox: React.FC<SkyboxProps> = (props: SkyboxProps) => {
-  return React.createElement("box", { size: 100, infiniteDistance: true, renderingGroupId: 0 }, [
+  return React.createElement("box", { size: props.size ?? 100, infiniteDistance: true, renderingGroupId: 0 }, [
     React.createElement("standardMaterial", { backFaceCulling: false, disableLighting: true }, [
       React.createElement("cubeTexture", {
         key: `cube-texture-${props.rootUrl}`, // changing rootUrl will reload the CubeTexture


### PR DESCRIPTION
Sometimes, it's useful to customize `Skybox` size.

I think the way to set a default value for size can be improved, but I'm not too familiar with TypeScript.