### PR TITLE
Allows using react suspense without error

### DIFF
--- a/src/ReactBabylonJSHostConfig.ts
+++ b/src/ReactBabylonJSHostConfig.ts
@@ -429,9 +429,9 @@ const ReactBabylonJSHostConfig: HostConfig<
     return false
   },
 
-  hideInstance(instance: CreatedInstance<any>) {},
-  
-  unhideInstance(instance: CreatedInstance<any>, props: Props) {},
+  hideInstance(instance: HostCreatedInstance<any>) {},
+
+  unhideInstance(instance: HostCreatedInstance<any>, props: Props) {},
 
   createTextInstance: (): any => {
     return undefined

--- a/src/ReactBabylonJSHostConfig.ts
+++ b/src/ReactBabylonJSHostConfig.ts
@@ -135,7 +135,10 @@ const ReactBabylonJSHostConfig: HostConfig<
   {},
   TimeoutHandler,
   NoTimeout
-> = {
+> & {
+   hideInstance: (instance: HostCreatedInstance<any>) => void;
+   unhideInstance: (instance: HostCreatedInstance<any>, props:Props) => void;
+} = {
   // This has the reconciler include in call chain ie: appendChild, removeChild
   get supportsMutation(): boolean {
     return true
@@ -425,6 +428,10 @@ const ReactBabylonJSHostConfig: HostConfig<
   shouldDeprioritizeSubtree: (type: string, props: Props): boolean => {
     return false
   },
+
+  hideInstance(instance: CreatedInstance<any>) {},
+  
+  unhideInstance(instance: CreatedInstance<any>, props: Props) {},
 
   createTextInstance: (): any => {
     return undefined


### PR DESCRIPTION
**Reason**
An error caused the app to stop while trying to make a hook that uses suspense

Based on this same issue and fix:
https://github.com/vadimdemedes/ink/pull/254

**Changes**
Adds required empty methods to prevent error when using react suspense 