### PR TITLE
Fix nonstandard package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "@babylonjs",
     "react-reconciler"
   ],
+  "main": "dist/react-babylonjs.js",
   "module": "dist/react-babylonjs.js",
+  "esnext": "dist/react-babylonjs.js",
   "type": "module",
   "typings": "dist/react-babylonjs.d.ts",
   "files": [


### PR DESCRIPTION
According to the Node.js document, a package should define a "main" or an "exports" field.

But current package.json only defines a "module" field, that’s nonstandard and will cause some tool can't resolve this package, see: benmosher/eslint-plugin-import#1778