### PR TITLE
Create Tunnel

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-dom": ">=17"
   },
   "dependencies": {
-    "react-reconciler": "^0.26.2"
+    "react-reconciler": "^0.26.2",
+    "zustand": "^3.6.1"
   }
 }

--- a/src/customComponents/Html.tsx
+++ b/src/customComponents/Html.tsx
@@ -18,7 +18,7 @@ function defaultCalculatePosition(el: AbstractMesh, camera: Camera) {
   const objectPos = el.getAbsolutePosition();
   const engine = camera.getEngine()
   const viewport = camera.viewport.toGlobal(engine.getRenderWidth(), engine.getRenderHeight());
-  const screenPos = Vector3.Project(objectPos, Matrix.Identity(), camera.getScene().getTransformMatrix(), viewport)
+  const screenPos = Vector3.Project(objectPos, Matrix.Identity(), camera.getTransformationMatrix(), viewport)
 
   return [screenPos.x * engine.getHardwareScalingLevel(), screenPos.y * engine.getHardwareScalingLevel()]
 }
@@ -237,36 +237,26 @@ const Html = forwardRef(
       } else {
         render(<div id="html_babylon" ref={ref} style={styles} className={className} children={children} />, el)
       }
-      // el && createPortal(<>
-      //   {transform ? <div id="html_babylon" ref={transformOuterRef} style={styles}>
-      //     <div ref={transformInnerRef} style={transformInnerStyles}>
-      //       <div ref={ref} className={className} style={style} children={children} />
-      //     </div>
-      //   </div>
-      //   :<div  id="html_babylon" ref={ref} style={styles} className={className} children={children} />}
-      //   </>, el)
-
     })
 
     const visible = useRef(true)
 
     useBeforeRender(() => {
-      let camera = scene?.activeCamera;
-
+      const camera = scene?.activeCamera;
+      
       if (camera && group.current) {
         const node = group.current as AbstractMesh;
         node.computeWorldMatrix(true)
-        //camera?.getWorldMatrix();
         const vec = transform ? oldPosition.current : calculatePosition(node, camera)
-
+       
         el.style.display = node.isEnabled(true) ? 'block' : 'none'
-
-        if (
-          transform ||
-          Math.abs(oldZoom.current - camera.fov) > eps ||
-          Math.abs(oldPosition.current[0] - vec[0]) > eps ||
-          Math.abs(oldPosition.current[1] - vec[1]) > eps
-        ) {
+ 
+        if ( (isNaN(vec[0]) === false) && (
+            transform ||
+            Math.abs(oldZoom.current - camera.fov) > eps ||
+            Math.abs(oldPosition.current[0] - vec[0]) > eps ||
+            Math.abs(oldPosition.current[1] - vec[1]) > eps
+          )) {
           const isBehindCamera = isObjectBehindCamera(node, camera)
 
           let raytraceTarget: null | undefined | boolean | AbstractMesh[] = false

--- a/src/customComponents/Tunnel.tsx
+++ b/src/customComponents/Tunnel.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, ReactElement} from 'react';
+import create from "zustand"
+/** 
+ * A tunnel allows to render components of one renderer inside another.
+ * I.e. babylonjs components normally need to live within Engine component.
+ * A tunnel entrance allows to position components in a different renderer, such as ReactDOM
+ * and move it to the tunnel exit, that must exist within Engine component.
+ *
+ * The nice thing is, even refs can be used outside of Engine context.
+ * 
+ * The createTunnel function creates a tunnel entrance and exit component.
+ * The tunnel works one-directional. 
+ * TunnelEntrance only accepts components that are allowed to live within the renderer of TunnelExit.
+ * Multiple entrances and exits are possible.
+ * 
+ * If components need to be rendererd the other way around, a second Tunnel is needed.
+ * 
+ */
+const createTunnel = () => {
+    /**
+     * Possible improvement: use key/value object to steer children from different entrances to different exits
+     * i.e. <TunnelEntrance id="hyperloop">
+     * <TunnelExit ids=["hyperloop"]>
+     */
+
+    type Store = {store: ReactElement[], add:(el:ReactElement)=>void, remove:(el:ReactElement)=>void}
+        const useStore = create<Store>((set, get)=> ({
+            store: [],
+            add: (el: ReactElement) => set((state)=>{
+                return {...state, store: [...state.store, el]}}),
+            remove: (el: ReactElement) => set((state)=>{return {...state, store: state.store.filter(e => e.key !== el.key)}})
+        }))
+
+    const TunnelEntrance = ({children}: {children: ReactElement}) => {
+        const add = useStore(state => state.add)
+        const remove = useStore(state => state.remove)
+        useEffect(()=>{
+            add(children);
+            return ()=> {
+                remove(children)
+            }
+        },[children])
+
+        return <></>
+    }
+
+    const TunnelExit = () => {
+        const state = useStore(state => state.store)
+        return <>{state.length > 0 && state.map(entry =>{
+                        return entry;
+                    }
+                )}
+            </>
+      }
+ 
+    return {TunnelEntrance, TunnelExit};
+}
+
+export default createTunnel;

--- a/src/customComponents/Tunnel.tsx
+++ b/src/customComponents/Tunnel.tsx
@@ -34,7 +34,7 @@ const createTunnel = () => {
             if(key in state.store){
                 delete state.store[key]
             }
-            return {...state, store: state.store}})
+            return {...state, store: {...state.store}}})
     }))
 
     /**

--- a/src/customComponents/index.ts
+++ b/src/customComponents/index.ts
@@ -2,4 +2,5 @@
 // export {default as ModelLifecycleListener} from "../customHosts/ModelLifecycleListener"
 export {default as Skybox} from "./Skybox";
 export {default as Model} from "./Model";
+export {default as createTunnel} from "./Tunnel";
 export {default as Html} from "./Html";

--- a/storybook/stories/babylonjs/Basic/tunnel.stories.js
+++ b/storybook/stories/babylonjs/Basic/tunnel.stories.js
@@ -29,7 +29,7 @@ const {TunnelEntrance, TunnelExit} = createTunnel();
 const rpm = 5;
 
 
-const WithTunnel = ()=>{
+const WithTunnel = ({uids})=>{
   const [_, setReady] = useState(false);
   const ref = useRef(null);
   useBeforeRender((scene) => {
@@ -45,7 +45,7 @@ const WithTunnel = ()=>{
   }, [ref.current])
 
   return <transformNode name="transform-node" ref={ref}>
-            <TunnelExit />
+            <TunnelExit uids={uids}/>
           </transformNode>
       
 }
@@ -67,22 +67,22 @@ export const CreateTunnel = () => {
   return <div style={{ flex: 1, display: 'flex' }}>
         <button onClick={()=>setPosition(Math.abs(position-1))}>Set Position</button>
         {/** Multiple Tunnel Entrances */}
-          <TunnelEntrance>
-            <box ref={ref} position={new Vector3(0, position, 0)}>
-              <standardMaterial diffuseColor={Color3.Blue() } specularColor={Color3.Black()} />
+          <TunnelEntrance uid="hyperloop">
+            <box name="box" ref={ref} position={new Vector3(0, position, 0)}>
+              <standardMaterial name="mat" diffuseColor={Color3.Blue() } specularColor={Color3.Black()} />
             </box>
           </TunnelEntrance>
-          <TunnelEntrance>
-            <box position={new Vector3(position, 0, 1)}>
-              <standardMaterial diffuseColor={Color3.Red() } specularColor={Color3.Black()} />
+          <TunnelEntrance uid="subway">
+            <box name="box" position={new Vector3(position, 0, 1)}>
+              <standardMaterial name="mat" diffuseColor={Color3.Red() } specularColor={Color3.Black()} />
             </box>
           </TunnelEntrance>
           <Engine antialias adaptToDeviceRatio canvasId='babylonJS'>
           <Scene>
             <freeCamera name='camera1' position={new Vector3(0, 5, -10)}
               setTarget={[Vector3.Zero()]} />
-              <WithTunnel />
-              <transformNode position={new Vector3(5, 0, 0)}>
+              <WithTunnel uids={["subway"]}/>
+              <transformNode name="node" position={new Vector3(5, 0, 0)}>
                 <WithTunnel />
               </transformNode>
               <hemisphericLight name='light1' intensity={0.7} direction={Vector3.Up()} />

--- a/storybook/stories/babylonjs/Basic/tunnel.stories.js
+++ b/storybook/stories/babylonjs/Basic/tunnel.stories.js
@@ -1,0 +1,92 @@
+import React, { useEffect, useRef, useState } from 'react';
+import '@babylonjs/inspector';
+import { Engine, Scene, useBeforeRender, createTunnel} from '../../../../dist/react-babylonjs';
+import { Vector3 } from '@babylonjs/core/Maths/math.vector';
+import { Color3 } from '@babylonjs/core/Maths/math.color';
+import '../../style.css'
+
+export default { title: 'Babylon Basic' };
+
+
+/** 
+ * A tunnel allows to render components of one renderer inside another.
+ * I.e. babylonjs components normally need to live within Engine component.
+ * A tunnel entrance allows to position components in a different renderer, such as ReactDOM
+ * and move it to the tunnel exit, that must exist within Engine component.
+ *
+ * The nice thing is, even refs can be used outside of Engine context.
+ * 
+ * The createTunnel function creates a tunnel entrance and exit component.
+ * The tunnel works one-directional. 
+ * TunnelEntrance only accepts components that are allowed to live within the renderer of TunnelExit.
+ * Multiple entrances and exits are possible.
+ * 
+ * If components need to be rendererd the other way around, a second Tunnel is needed.
+ * 
+ */
+const {TunnelEntrance, TunnelExit} = createTunnel();
+
+const rpm = 5;
+
+
+const WithTunnel = ()=>{
+  const [_, setReady] = useState(false);
+  const ref = useRef(null);
+  useBeforeRender((scene) => {
+    
+    if (ref.current !== null) {
+      const deltaTimeInMillis = scene.getEngine().getDeltaTime();
+      ref.current.rotation.y += ((rpm / 60) * Math.PI * 2 * (deltaTimeInMillis / 1000));
+    }
+  })
+
+  useEffect(() => {
+    setReady(true);
+  }, [ref.current])
+
+  return <transformNode name="transform-node" ref={ref}>
+            <TunnelExit />
+          </transformNode>
+      
+}
+
+
+export const CreateTunnel = () => {
+
+  /** ref to tunnel is possible */
+  const ref = useRef(null)
+  
+  const [position, setPosition] = useState(1)
+
+  useEffect(()=>{
+    if(ref.current){
+      ref.current.position.x = Math.abs(position-4);
+    }
+  },[position])
+
+  return <div style={{ flex: 1, display: 'flex' }}>
+        <button onClick={()=>setPosition(Math.abs(position-1))}>Set Position</button>
+        {/** Multiple Tunnel Entrances */}
+          <TunnelEntrance>
+            <box ref={ref} position={new Vector3(0, position, 0)}>
+              <standardMaterial diffuseColor={Color3.Blue() } specularColor={Color3.Black()} />
+            </box>
+          </TunnelEntrance>
+          <TunnelEntrance>
+            <box position={new Vector3(position, 0, 1)}>
+              <standardMaterial diffuseColor={Color3.Red() } specularColor={Color3.Black()} />
+            </box>
+          </TunnelEntrance>
+          <Engine antialias adaptToDeviceRatio canvasId='babylonJS'>
+          <Scene>
+            <freeCamera name='camera1' position={new Vector3(0, 5, -10)}
+              setTarget={[Vector3.Zero()]} />
+              <WithTunnel />
+              <transformNode position={new Vector3(5, 0, 0)}>
+                <WithTunnel />
+              </transformNode>
+              <hemisphericLight name='light1' intensity={0.7} direction={Vector3.Up()} />
+            </Scene>
+          </Engine>
+  </div>
+}


### PR DESCRIPTION
hi @brianzinn,

I figured out a way to pass components from one renderer to another while keeping context and refs. 
Since portal stay within renderer and bridges only pass context hierarchically into other renderers, i justed named it tunnel.

I added some comments to the component:
>A tunnel allows to render components of one renderer inside another.
>I.e. babylonjs components normally need to live within Engine component.
>A tunnel entrance allows to position components in a different renderer, such as ReactDOM
>and move it to the tunnel exit, that must exist within Engine component.
>
>The nice thing is, even refs can be used outside of Engine context.
>
>The createTunnel function creates a tunnel entrance and exit component.
>The tunnel works one-directional. 
>TunnelEntrance only accepts components that are allowed to live within the renderer of TunnelExit.
>Multiple entrances and exits are possible.
>
>If components need to be rendererd the other way around, a second Tunnel is needed.


I am not sure, how stable it is. 
Besides the storybook, which sends bjs components from outside engine into engine, i also tried to send reactdom data from within bjs outside of it. it connects to the context of the renderer it is send to. and refs seem to work, too.
i used zustand to make this work. also tried valtio, but had issues with rerendering and keeping refs. both state libraries can live outside of react, but trigger state changes. therefore they seemed ideal to send data from a to b. hope it will be stable..

![mixedrenderers](https://user-images.githubusercontent.com/29654902/139043440-64ccdeeb-896e-4a67-8b8c-3bd28d34c905.gif)


