### PR TITLE
[critical fix] useBeforeRender repeatedly registering callbacks on each frame

### DIFF
--- a/packages/react-babylonjs/src/hooks/render.ts
+++ b/packages/react-babylonjs/src/hooks/render.ts
@@ -41,7 +41,7 @@ export const useBeforeRender = (
         scene.onBeforeRenderObservable.remove(sceneObserver)
       }
     }
-  })
+  }, [])
 }
 
 /**


### PR DESCRIPTION
Here's a codesandbox that will crash hard because `useEffect` inside `useBeforeRender` is registering thousands of callbacks 🗡️ 

http://codesandbox.io/s/codesandbox-react-tsx-forked-fdzgy?file=/src/App.tsx:367-382