### PR TITLE
Strongly typed ref in BabylonNode<T>

### DIFF
--- a/packages/react-babylonjs/tools/generate-code.ts
+++ b/packages/react-babylonjs/tools/generate-code.ts
@@ -1975,7 +1975,7 @@ const generateCode = async () => {
         },
         {
           name: 'ref',
-          type: 'Ref<ReactNode>',
+          type: 'Ref<T>',
           hasQuestionToken: true,
         },
       ],


### PR DESCRIPTION
Fixes typescript error for a given case:
```jsx
const ref = useRef<Mesh>();
useEffect(() => {
  const mesh = ref.current;
}, []);
return <mesh ref={ref} />
```

Without that change one needs to write below code to workaround type check errors which defeats the purpose:
```jsx
const ref = useRef();
useEffect(() => {
  const mesh = ref.current as Mesh;
}, []);
return <mesh ref={ref} />
```
