### PR TITLE
feat : ✨ resolve [TODO] - provide file size of imported mesh

### DIFF
--- a/packages/storybook/stories/babylonjs/ScaledModelWithProgress.js
+++ b/packages/storybook/stories/babylonjs/ScaledModelWithProgress.js
@@ -12,9 +12,7 @@ const ProgressFallback = (props) => {
   let loadProgress = 0;
   if (sceneLoaderContext.lastProgress) {
     const progress = sceneLoaderContext.lastProgress;
-    loadProgress = progress.lengthComputable
-      ? progress.loaded / progress.total
-      : progress.loaded / 10000; // TODO: provide option to input file size for proper loading.
+    loadProgress = progress.loaded / progress.total;
   }
 
   return (


### PR DESCRIPTION
Hi @brianzinn 
while I use model's onProgress or sceneLoader.Context's progress, I found unresolved TODO feature that load correct file size

So, I resolve this in an simple way
let me show you before and after video

before it was modified, GUI progress had not correct length and not total length ( written as `10000`) when import asset file

https://user-images.githubusercontent.com/70849655/164709710-99a56d35-32d2-4ff9-9565-04349cfb3e99.mp4

and after modified, GUi progress run correctly

https://user-images.githubusercontent.com/70849655/164709833-ccb4d7e5-22d8-4316-a941-0d1e517b723a.mp4

if there is any issue , please know me
 