### PR TITLE
useBeforeCameraRender and useAfterCameraRender hook

### DIFF
--- a/packages/react-babylonjs/src/hooks/render.ts
+++ b/packages/react-babylonjs/src/hooks/render.ts
@@ -1,10 +1,12 @@
 import { EventState, Observer } from '@babylonjs/core/Misc/observable.js'
 import { Scene } from '@babylonjs/core/scene.js'
+import { Camera } from "@babylonjs/core/Cameras/camera"
 import { Nullable } from '@babylonjs/core/types.js'
 import { useContext, useEffect } from 'react'
 import { SceneContext } from './scene'
 
 export type OnFrameRenderFn = (eventData: Scene, eventState: EventState) => void
+export type OnCameraRenderFn = (eventData: Camera, eventState: EventState) => void
 
 /**
  * Register a callback for before the scene renders.
@@ -47,7 +49,7 @@ export const useBeforeRender = (
 /**
  * Register a callback for after the scene renders.
  *
- * @param callback called using onBeforeRender functionality of scene
+ * @param callback called using onAfterRender functionality of scene
  * @param mask the mask used to filter observers
  * @param insertFirst if true will be inserted at first position, if false (default) will be last position.
  * @param callOnce only call the callback once
@@ -80,4 +82,80 @@ export const useAfterRender = (
       }
     }
   })
+}
+
+/**
+ * Register a callback for before the camera renders.
+ *
+ * @param callback called using useBeforeCameraRender functionality of scene
+ * @param mask the mask used to filter observers
+ * @param insertFirst if true will be inserted at first position, if false (default) will be last position.
+ * @param callOnce only call the callback once
+ */
+ export const useBeforeCameraRender = (
+	callback: OnCameraRenderFn,
+	mask?: number,
+	insertFirst?: boolean,
+	callOnce?: boolean,
+	deps: React.DependencyList = []
+  ): void => {
+	const { scene } = useContext(SceneContext)
+
+	useEffect(() => {
+		if (scene === null) {
+			return
+		}
+		const unregisterOnFirstCall: boolean = callOnce === true
+		const sceneObserver: Nullable<Observer<Camera>> = scene.onBeforeCameraRenderObservable.add(
+			callback,
+			mask,
+			insertFirst,
+			undefined,
+			unregisterOnFirstCall,
+		)
+
+		if (unregisterOnFirstCall !== true) {
+			return () => {
+				scene.onBeforeCameraRenderObservable.remove(sceneObserver)
+			}
+		}
+	}, [scene, ...deps])
+}
+
+/**
+ * Register a callback for after the scene renders.
+ *
+ * @param callback called using onAfterCameraRender functionality of scene
+ * @param mask the mask used to filter observers
+ * @param insertFirst if true will be inserted at first position, if false (default) will be last position.
+ * @param callOnce only call the callback once
+ */
+ export const useAfterCameraRender = (
+	callback: OnCameraRenderFn,
+	mask?: number,
+	insertFirst?: boolean,
+	callOnce?: boolean,
+): void => {
+	const { scene } = useContext(SceneContext)
+
+	useEffect(() => {
+		if (scene === null) {
+			return
+		}
+
+		const unregisterOnFirstCall: boolean = callOnce === true
+		const sceneObserver: Nullable<Observer<Camera>> = scene.onAfterCameraRenderObservable.add(
+			callback,
+			mask,
+			insertFirst,
+			undefined,
+			unregisterOnFirstCall,
+		)
+
+		if (unregisterOnFirstCall !== true) {
+			return () => {
+				scene.onAfterCameraRenderObservable.remove(sceneObserver)
+			}
+		}
+	})
 }

--- a/packages/react-babylonjs/src/hooks/render.ts
+++ b/packages/react-babylonjs/src/hooks/render.ts
@@ -1,6 +1,6 @@
 import { EventState, Observer } from '@babylonjs/core/Misc/observable.js'
 import { Scene } from '@babylonjs/core/scene.js'
-import { Camera } from "@babylonjs/core/Cameras/camera"
+import { Camera } from "@babylonjs/core/Cameras/camera.js"
 import { Nullable } from '@babylonjs/core/types.js'
 import { useContext, useEffect } from 'react'
 import { SceneContext } from './scene'


### PR DESCRIPTION
implement of useBeforeCameraRender and useAfterCameraRender to work with multiple cameras like VR eyes

This is an easy alternative to get active shader for camera

useBeforeCameraRender  is used in textureDome (PhotoDome) to check current eye of camera https://github.com/BabylonJS/Babylon.js/blob/fdbf393d1d7699dc7cc69cec1dca0819ebd2622a/packages/dev/core/src/Helpers/textureDome.ts