### PR TITLE
feat: add support for PhysicsAggregate

### DIFF
--- a/packages/react-babylonjs/src/customHosts/PhysicsAggregateLifecycleListener.ts
+++ b/packages/react-babylonjs/src/customHosts/PhysicsAggregateLifecycleListener.ts
@@ -1,0 +1,53 @@
+import {
+  PhysicsAggregate,
+  PhysicsAggregateParameters,
+} from '@babylonjs/core/Physics/v2/physicsAggregate.js'
+import { TransformNode } from '@babylonjs/core/Meshes/transformNode.js'
+import { Scene } from '@babylonjs/core/scene.js'
+import { Nullable } from '@babylonjs/core/types.js'
+import { CreatedInstance } from '../CreatedInstance'
+import DeferredCreationLifecycleListener from './DeferredCreationLifecycleListener'
+
+/**
+ * There is a lot going on in the PhysicsImpostor constructor, so we delay instantiation so that we have a target
+ * 'object' before creation.
+ */
+export default class PhysicsImpostorLifecycleListener extends DeferredCreationLifecycleListener<
+  PhysicsAggregate,
+  any
+> {
+  private _parent: TransformNode | undefined
+
+  createInstance = (
+    instance: CreatedInstance<PhysicsAggregate>,
+    scene: Scene,
+    props: any
+  ): Nullable<PhysicsAggregate> => {
+    if (!this._parent) {
+      return null
+    }
+    // these should be set from the props handler.  TODO: test.
+    const options: PhysicsAggregateParameters = props._options // constructor has a default { mass: 0 }
+
+    instance.hostInstance = new PhysicsAggregate(this._parent, props.type, options, this.scene!)
+    instance.hostInstance.transformNode = this._parent
+    ;(this._parent as any).physicsImpostor = instance.hostInstance
+    // TODO: need to assign deferredCreationProps (@see ShadowGeneratorLifecycleListener).
+
+    return instance.hostInstance
+  }
+
+  onParented(parent: CreatedInstance<any>, child: CreatedInstance<any>): any {
+    super.onParented(parent, child)
+    // IPhysicsEnabledObject requires only position and rotationQuaternion
+    if (
+      parent.hostInstance.position === undefined ||
+      parent.hostInstance.rotationQuaternion === undefined
+    ) {
+      console.warn(
+        'PhysicsImpostor is parented to an element that does not appear to implement IPhysicsEnabledObject'
+      )
+    }
+    this._parent = parent.hostInstance
+  }
+}

--- a/packages/react-babylonjs/src/customHosts/index.ts
+++ b/packages/react-babylonjs/src/customHosts/index.ts
@@ -21,6 +21,7 @@ export { default as GUI3DManagerLifecycleListener } from './GUI3DManagerLifecycl
 export { default as MaterialsLifecycleListener } from './MaterialsLifecycleListener'
 export { default as NodeLifecycleListener } from './NodeLifecycleListener'
 export { default as PhysicsImpostorLifecycleListener } from './PhysicsImpostorLifecycleListener'
+export { default as PhysicsAggregateLifecycleListener } from './PhysicsAggregateLifecycleListener'
 export { default as ShadowGeneratorLifecycleListener } from './ShadowGeneratorLifecycleListener'
 export { default as TargetPropsHandler } from './TargetPropsHandler'
 export { default as TexturesLifecycleListener } from './TexturesLifecycleListener'

--- a/packages/react-babylonjs/src/generatedCode.ts
+++ b/packages/react-babylonjs/src/generatedCode.ts
@@ -131,6 +131,7 @@ import { TransformNode as BabylonjsCoreTransformNode } from '@babylonjs/core/Mes
 import { Node as BabylonjsCoreNode } from '@babylonjs/core/node.js'
 import { PointsCloudSystem as BabylonjsCorePointsCloudSystem } from '@babylonjs/core/Particles/pointsCloudSystem.js'
 import { PhysicsImpostor as BabylonjsCorePhysicsImpostor } from '@babylonjs/core/Physics/v1/physicsImpostor.js'
+import { PhysicsAggregate as BabylonjsCorePhysicsAggregate } from '@babylonjs/core/Physics/v2/physicsAggregate.js'
 import { AnaglyphPostProcess as BabylonjsCoreAnaglyphPostProcess } from '@babylonjs/core/PostProcesses/anaglyphPostProcess.js'
 import { BlackAndWhitePostProcess as BabylonjsCoreBlackAndWhitePostProcess } from '@babylonjs/core/PostProcesses/blackAndWhitePostProcess.js'
 import { BloomMergePostProcess as BabylonjsCoreBloomMergePostProcess } from '@babylonjs/core/PostProcesses/bloomMergePostProcess.js'
@@ -393,6 +394,7 @@ import {
   FiberPBRSheenConfigurationProps,
   FiberPBRSpecularGlossinessMaterialProps,
   FiberPBRSubSurfaceConfigurationProps,
+  FiberPhysicsAggregateProps,
   FiberPhysicsImpostorProps,
   FiberPlaneDragGizmoProps,
   FiberPlanePanelProps,
@@ -2009,7 +2011,7 @@ export class FiberCameraPropsHandler implements PropsHandler<FiberCameraProps> {
     checkPrimitiveDiff(oldProps.maxZ, newProps.maxZ, 'maxZ', changedProps)
     checkPrimitiveDiff(oldProps.minZ, newProps.minZ, 'minZ', changedProps)
     checkPrimitiveDiff(oldProps.mode, newProps.mode, 'mode', changedProps)
-    // type: 'IObliqueParams' property (not coded) BabylonjsCoreCamera.oblique.
+    // type: 'BabylonjsCoreIObliqueParams' property (not coded) BabylonjsCoreCamera.oblique.
     checkObservableDiff(
       oldProps.onAfterCheckInputsObservable,
       newProps.onAfterCheckInputsObservable,
@@ -12855,6 +12857,12 @@ export class FiberControlPropsHandler implements PropsHandler<FiberControlProps>
       oldProps.onDisposeObservable,
       newProps.onDisposeObservable,
       'onDisposeObservable',
+      changedProps
+    )
+    checkObservableDiff(
+      oldProps.onEnabledStateChangedObservable,
+      newProps.onEnabledStateChangedObservable,
+      'onEnabledStateChangedObservable',
       changedProps
     )
     checkObservableDiff(
@@ -25778,6 +25786,77 @@ export class FiberPhysicsImpostor implements HasPropsHandlers<FiberPhysicsImpost
   }
 }
 
+export class FiberPhysicsAggregatePropsHandler implements PropsHandler<FiberPhysicsAggregateProps> {
+  getPropertyUpdates(
+    oldProps: FiberPhysicsAggregateProps,
+    newProps: FiberPhysicsAggregateProps
+  ): PropertyUpdate[] | null {
+    // skipping type: 'BabylonjsCorePhysicsBody' property (not coded) BabylonjsCorePhysicsAggregate.body.
+    // skipping type: 'BabylonjsCorePhysicsMaterial' property (not coded) BabylonjsCorePhysicsAggregate.material.
+    // skipping type: 'BabylonjsCorePhysicsShape' property (not coded) BabylonjsCorePhysicsAggregate.shape.
+    // skipping type: 'BabylonjsCoreTransformNode' property (not coded) BabylonjsCorePhysicsAggregate.transformNode.
+    // skipping type: 'BabylonjsCorePhysicsShapeType | BabylonjsCorePhysicsShape' property (not coded) BabylonjsCorePhysicsAggregate.type.
+    return null // no props to check
+  }
+}
+
+/**
+ * Helper class to create and interact with a PhysicsAggregate.
+ * This is a transition object that works like Physics Plugin V1 Impostors.
+ * This helper instanciate all mandatory physics objects to get a body/shape and material.
+ * It's less efficient that handling body and shapes independently but for prototyping or
+ * a small numbers of physics objects, it's good enough.
+ *
+ * This code has been generated
+ */
+export class FiberPhysicsAggregate implements HasPropsHandlers<FiberPhysicsAggregateProps> {
+  private propsHandlers: PropsHandler<FiberPhysicsAggregateProps>[]
+
+  constructor() {
+    this.propsHandlers = [new FiberPhysicsAggregatePropsHandler()]
+  }
+
+  getPropsHandlers(): PropsHandler<FiberPhysicsAggregateProps>[] {
+    return this.propsHandlers
+  }
+
+  addPropsHandler(propHandler: PropsHandler<FiberPhysicsAggregateProps>): void {
+    this.propsHandlers.push(propHandler)
+  }
+
+  public static readonly CreateInfo = {
+    creationType: 'Constructor',
+    libraryLocation: 'PhysicsAggregate',
+    namespace: '@babylonjs/core',
+    parameters: [
+      {
+        name: 'transformNode',
+        type: 'BabylonjsCoreTransformNode',
+        optional: true,
+      },
+      {
+        name: 'type',
+        type: 'BabylonjsCorePhysicsShapeType | BabylonjsCorePhysicsShape',
+        optional: false,
+      },
+      {
+        name: '_options',
+        type: 'BabylonjsCorePhysicsAggregateParameters',
+        optional: true,
+      },
+      {
+        name: '_scene',
+        type: 'BabylonjsCoreScene',
+        optional: true,
+      },
+    ],
+  }
+  public static readonly Metadata: CreatedInstanceMetadata = {
+    delayCreation: true,
+    className: 'FiberPhysicsAggregate',
+  }
+}
+
 export class FiberVRExperienceHelperPropsHandler
   implements PropsHandler<FiberVRExperienceHelperProps>
 {
@@ -30210,6 +30289,7 @@ export const ADTForMesh: string = 'ADTForMesh',
   PBRSubSurfaceConfiguration: string = 'PBRSubSurfaceConfiguration',
   PassCubePostProcess: string = 'PassCubePostProcess',
   PassPostProcess: string = 'PassPostProcess',
+  PhysicsAggregate: string = 'PhysicsAggregate',
   PhysicsImpostor: string = 'PhysicsImpostor',
   Plane: string = 'Plane',
   PlaneDragGizmo: string = 'PlaneDragGizmo',
@@ -30393,6 +30473,8 @@ const classesMap: Record<string, any> = {
   GreasedLineBaseMesh: BabylonjsCoreGreasedLineBaseMesh,
   physicsImpostor: BabylonjsCorePhysicsImpostor,
   PhysicsImpostor: BabylonjsCorePhysicsImpostor,
+  physicsAggregate: BabylonjsCorePhysicsAggregate,
+  PhysicsAggregate: BabylonjsCorePhysicsAggregate,
   postProcessRenderPipeline: BabylonjsCorePostProcessRenderPipeline,
   PostProcessRenderPipeline: BabylonjsCorePostProcessRenderPipeline,
   control: BabylonjsGuiControl,
@@ -30830,6 +30912,7 @@ export const intrinsicClassMap: object = {
   thinTexture: 'ThinTexture',
   greasedLineBaseMesh: 'GreasedLineBaseMesh',
   physicsImpostor: 'PhysicsImpostor',
+  physicsAggregate: 'PhysicsAggregate',
   postProcessRenderPipeline: 'PostProcessRenderPipeline',
   control: 'Control',
   textBlock: 'TextBlock',

--- a/packages/react-babylonjs/src/generatedProps.ts
+++ b/packages/react-babylonjs/src/generatedProps.ts
@@ -22,7 +22,10 @@ import { SurfaceMagnetismBehavior as BabylonjsCoreSurfaceMagnetismBehavior } fro
 import { Skeleton as BabylonjsCoreSkeleton } from '@babylonjs/core/Bones/skeleton.js'
 import { ArcRotateCamera as BabylonjsCoreArcRotateCamera } from '@babylonjs/core/Cameras/arcRotateCamera.js'
 import { ArcRotateCameraInputsManager as BabylonjsCoreArcRotateCameraInputsManager } from '@babylonjs/core/Cameras/arcRotateCameraInputsManager.js'
-import { Camera as BabylonjsCoreCamera } from '@babylonjs/core/Cameras/camera.js'
+import {
+  Camera as BabylonjsCoreCamera,
+  IObliqueParams as BabylonjsCoreIObliqueParams,
+} from '@babylonjs/core/Cameras/camera.js'
 import { CameraInputsManager as BabylonjsCoreCameraInputsManager } from '@babylonjs/core/Cameras/cameraInputsManager.js'
 import { DeviceOrientationCamera as BabylonjsCoreDeviceOrientationCamera } from '@babylonjs/core/Cameras/deviceOrientationCamera.js'
 import { FlyCamera as BabylonjsCoreFlyCamera } from '@babylonjs/core/Cameras/flyCamera.js'
@@ -280,6 +283,14 @@ import {
   PhysicsImpostor as BabylonjsCorePhysicsImpostor,
   PhysicsImpostorParameters as BabylonjsCorePhysicsImpostorParameters,
 } from '@babylonjs/core/Physics/v1/physicsImpostor.js'
+import { PhysicsShapeType as BabylonjsCorePhysicsShapeType } from '@babylonjs/core/Physics/v2/IPhysicsEnginePlugin.js'
+import {
+  PhysicsAggregate as BabylonjsCorePhysicsAggregate,
+  PhysicsAggregateParameters as BabylonjsCorePhysicsAggregateParameters,
+} from '@babylonjs/core/Physics/v2/physicsAggregate.js'
+import { PhysicsBody as BabylonjsCorePhysicsBody } from '@babylonjs/core/Physics/v2/physicsBody.js'
+import { PhysicsMaterial as BabylonjsCorePhysicsMaterial } from '@babylonjs/core/Physics/v2/physicsMaterial.js'
+import { PhysicsShape as BabylonjsCorePhysicsShape } from '@babylonjs/core/Physics/v2/physicsShape.js'
 import { AnaglyphPostProcess as BabylonjsCoreAnaglyphPostProcess } from '@babylonjs/core/PostProcesses/anaglyphPostProcess.js'
 import { BlackAndWhitePostProcess as BabylonjsCoreBlackAndWhitePostProcess } from '@babylonjs/core/PostProcesses/blackAndWhitePostProcess.js'
 import { BloomMergePostProcess as BabylonjsCoreBloomMergePostProcess } from '@babylonjs/core/PostProcesses/bloomMergePostProcess.js'
@@ -1049,6 +1060,9 @@ declare global {
       physicsImpostor: FiberPhysicsImpostorProps &
         FiberPhysicsImpostorPropsCtor &
         BabylonNode<BabylonjsCorePhysicsImpostor>
+      physicsAggregate: FiberPhysicsAggregateProps &
+        FiberPhysicsAggregatePropsCtor &
+        BabylonNode<BabylonjsCorePhysicsAggregate>
       vrExperienceHelper: FiberVRExperienceHelperProps &
         FiberVRExperienceHelperPropsCtor &
         BabylonNode<BabylonjsCoreVRExperienceHelper>
@@ -1411,7 +1425,7 @@ export type FiberCameraProps = {
   maxZ?: number
   minZ?: number
   mode?: number
-  oblique?: any
+  oblique?: BabylonjsCoreIObliqueParams
   onAfterCheckInputsObservable?: any
   onProjectionMatrixChangedObservable?: any
   onRestoreStateObservable?: any
@@ -3106,6 +3120,7 @@ export type FiberControlProps = {
   onBeforeDrawObservable?: any
   onDirtyObservable?: any
   onDisposeObservable?: any
+  onEnabledStateChangedObservable?: any
   onIsVisibleChangedObservable?: any
   onPointerClickObservable?: any
   onPointerDownObservable?: any
@@ -5243,6 +5258,18 @@ export type FiberPhysicsImpostorPropsCtor = {
   object?: BabylonjsCoreIPhysicsEnabledObject
   type: number
   _options?: BabylonjsCorePhysicsImpostorParameters
+}
+export type FiberPhysicsAggregateProps = {
+  body?: BabylonjsCorePhysicsBody
+  material?: BabylonjsCorePhysicsMaterial
+  shape?: BabylonjsCorePhysicsShape
+  transformNode?: BabylonjsCoreTransformNode
+  type?: BabylonjsCorePhysicsShapeType | BabylonjsCorePhysicsShape
+} & CustomProps
+export type FiberPhysicsAggregatePropsCtor = {
+  transformNode?: BabylonjsCoreTransformNode
+  type: BabylonjsCorePhysicsShapeType | BabylonjsCorePhysicsShape
+  _options?: BabylonjsCorePhysicsAggregateParameters
 }
 export type FiberVRExperienceHelperProps = {
   addFloorMesh?: any

--- a/packages/react-babylonjs/tools/generate-code.ts
+++ b/packages/react-babylonjs/tools/generate-code.ts
@@ -73,6 +73,7 @@ const GENERATE_KEBAB_ACCESSORS = true // test for Vector3 only currently
  */
 const LATE_BOUND_CONSTRUCTOR_PARAMETERS: Map<string, string[]> = new Map<string, string[]>([
   ['PhysicsImpostor', ['object']],
+  ['PhysicsAggregate', ['transformNode']],
   ['ShadowGenerator', ['light']],
   ['CascadedShadowGenerator', ['light']],
 ])
@@ -205,6 +206,7 @@ const classesToGenerate: String[] = [
   'CascadedShadowGenerator',
   'EnvironmentHelper',
   'PhysicsImpostor',
+  'PhysicsAggregate',
   'VRExperienceHelper',
   'DynamicTerrain',
   'EffectLayer',
@@ -2305,6 +2307,13 @@ const generateCode = async () => {
   )
   createSingleClass(
     'PhysicsImpostor',
+    generatedCodeSourceFile,
+    generatedPropsSourceFile,
+    undefined,
+    { delayCreation: true }
+  )
+  createSingleClass(
+    'PhysicsAggregate',
     generatedCodeSourceFile,
     generatedPropsSourceFile,
     undefined,

--- a/packages/static/content/examples/physics/BouncySphere2.tsx
+++ b/packages/static/content/examples/physics/BouncySphere2.tsx
@@ -1,0 +1,100 @@
+import { FresnelParameters } from '@babylonjs/core/Materials/fresnelParameters'
+import { Texture } from '@babylonjs/core/Materials/Textures/texture'
+import { Color3 } from '@babylonjs/core/Maths/math.color'
+import { Vector3 } from '@babylonjs/core/Maths/math.vector'
+import { Mesh } from '@babylonjs/core/Meshes/mesh'
+import { PhysicsShapeType } from '@babylonjs/core/Physics/v2/IPhysicsEnginePlugin'
+import { PhysicsAggregate } from '@babylonjs/core/Physics/v2/physicsAggregate'
+import { Nullable } from '@babylonjs/core/types'
+import { AdvancedDynamicTexture } from '@babylonjs/gui/2D/advancedDynamicTexture'
+import { useRef, useEffect, FC } from 'react'
+
+type BouncySphereProps = {
+  fontsReady: boolean
+  position: Vector3
+  name: string
+  color: Color3
+}
+
+const BouncySphere: FC<BouncySphereProps> = ({ fontsReady, position, name, color }) => {
+  const sphereAggRef = useRef<Nullable<PhysicsAggregate>>(null)
+  const adtRef = useRef<AdvancedDynamicTexture | null>(null)
+
+  useEffect(() => {
+    if (adtRef.current) {
+      console.log('marking dirty')
+      adtRef.current!.markAsDirty()
+    } else {
+      console.log('no ref')
+    }
+  }, [fontsReady, adtRef])
+
+  const onButtonClicked = () => {
+    if (sphereAggRef.current) {
+      sphereAggRef.current.body!.applyImpulse(
+        Vector3.Up().scale(10),
+        sphereAggRef.current.transformNode.getAbsolutePosition()
+      )
+    }
+  }
+
+  return (
+    <sphere name={`${name}-sphere`} diameter={2} segments={16} position={position}>
+      <physicsAggregate
+        ref={sphereAggRef}
+        type={PhysicsShapeType.SPHERE}
+        _options={{ mass: 1, restitution: 0.9 }}
+      />
+      <standardMaterial
+        name={`${name}-material`}
+        specularPower={16}
+        diffuseColor={Color3.Black()}
+        emissiveColor={color}
+        reflectionFresnelParameters={FresnelParameters.Parse({
+          isEnabled: true,
+          leftColor: [1, 1, 1],
+          rightColor: [0, 0, 0],
+          bias: 0.1,
+          power: 1,
+        })}
+      />
+      <plane
+        name={`${name}-dialog`}
+        size={2}
+        position={new Vector3(0, 1.5, 0)}
+        sideOrientation={Mesh.BACKSIDE}
+      >
+        <advancedDynamicTexture
+          name="dialogTexture"
+          ref={adtRef}
+          height={1024}
+          width={1024}
+          createForParentMesh={true}
+          hasAlpha={true}
+          generateMipMaps={true}
+          samplingMode={Texture.TRILINEAR_SAMPLINGMODE}
+        >
+          <rectangle name={`${name}-rect`} height={0.5} width={1} thickness={12} cornerRadius={12}>
+            <rectangle>
+              <babylon-button
+                name={`${name}-close-icon`}
+                background="green"
+                onPointerDownObservable={onButtonClicked}
+              >
+                <textBlock
+                  text={`${fontsReady ? '\uf00d' : 'X'} click ${name}`}
+                  fontFamily="FontAwesome"
+                  fontStyle="bold"
+                  fontSize={200}
+                  color="white"
+                />
+              </babylon-button>
+            </rectangle>
+          </rectangle>
+        </advancedDynamicTexture>
+      </plane>
+    </sphere>
+  )
+}
+
+export default BouncySphere

--- a/packages/static/content/examples/physics/Physics2.tsx
+++ b/packages/static/content/examples/physics/Physics2.tsx
@@ -1,0 +1,123 @@
+import React, { useState, useRef, FC, useEffect } from 'react'
+
+import '@babylonjs/core/Physics/physicsEngineComponent' // side-effect adds scene.enablePhysics function
+import '@babylonjs/core/Lights/Shadows/shadowGeneratorSceneComponent' // side-effect for shadow generator
+import { HavokPlugin } from '@babylonjs/core/Physics/v2/Plugins/havokPlugin'
+import { Vector3 } from '@babylonjs/core/Maths/math.vector'
+import { PhysicsShapeType } from '@babylonjs/core/Physics/v2/IPhysicsEnginePlugin'
+
+import { Scene, Engine } from 'react-babylonjs'
+
+import BouncySphere from './BouncySphere2'
+
+import HavokPhysics, { HavokPhysicsWithBindings } from '@babylonjs/havok'
+import { Color3 } from '@babylonjs/core'
+
+// build error that 'window is not defined'
+// window.CANNON = CANNON;
+
+const gravityVector = new Vector3(0, -9.81, 0)
+const RADIUS = 5
+const NUMBER_OF_BOXES = 8
+
+const App: FC = () => {
+  const [fontsReady, setFontsReady] = useState(false)
+  const [HK, setHK] = useState<HavokPhysicsWithBindings>()
+
+  const faLoaded = useRef(false)
+  useEffect(() => {
+    if (document.fonts.check('16px FontAwesome') === false) {
+      document.fonts.load('16px FontAwesome').then(() => {
+        if (faLoaded.current !== true) {
+          faLoaded.current = true
+          setFontsReady(true)
+        }
+      })
+    } else if (faLoaded.current !== true) {
+      faLoaded.current = true
+      setFontsReady(true)
+    }
+    ;(async () => {
+      setHK(await HavokPhysics())
+    })()
+  }, [])
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <Engine antialias={true} adaptToDeviceRatio={true} canvasId="sample-canvas">
+          {HK ? (
+            <Scene enablePhysics={[null, new HavokPlugin(false, HK)]}>
+              <arcRotateCamera
+                name="arc"
+                target={new Vector3(0, 1, 0)}
+                alpha={-Math.PI / 2}
+                beta={0.2 + Math.PI / 4}
+                wheelPrecision={50}
+                radius={14}
+                minZ={0.001}
+                lowerRadiusLimit={8}
+                upperRadiusLimit={20}
+                upperBetaLimit={Math.PI / 2}
+              />
+              <hemisphericLight name="hemi" direction={new Vector3(0, -1, 0)} intensity={0.8} />
+              <directionalLight
+                name="shadow-light"
+                setDirectionToTarget={[Vector3.Zero()]}
+                direction={Vector3.Zero()}
+                position={new Vector3(-40, 30, -40)}
+                intensity={0.4}
+                shadowMinZ={1}
+                shadowMaxZ={2500}
+              >
+                <shadowGenerator
+                  mapSize={1024}
+                  useBlurExponentialShadowMap={true}
+                  blurKernel={32}
+                  darkness={0.8}
+                  forceBackFacesOnly={true}
+                  depthScale={100}
+                  shadowCastChildren
+                >
+                  {Array.from(new Array(NUMBER_OF_BOXES), (_, index) => index).map((x) => (
+                    <BouncySphere
+                      key={x}
+                      name={x.toFixed()}
+                      fontsReady={fontsReady}
+                      position={
+                        new Vector3(
+                          Math.cos(((2 * Math.PI) / NUMBER_OF_BOXES) * x) * RADIUS,
+                          3,
+                          Math.sin(((2 * Math.PI) / NUMBER_OF_BOXES) * x) * RADIUS
+                        )
+                      }
+                      color={
+                        new Color3(
+                          Math.abs(x - NUMBER_OF_BOXES / 2) / 10,
+                          Math.abs(x - NUMBER_OF_BOXES / 2) / 10,
+                          Math.abs(x - NUMBER_OF_BOXES / 2) / 10
+                        )
+                      }
+                    />
+                  ))}
+                </shadowGenerator>
+              </directionalLight>
+
+              <ground name="ground1" width={24} height={24} subdivisions={2} receiveShadows={true}>
+                <physicsAggregate
+                  type={PhysicsShapeType.BOX}
+                  _options={{ mass: 0, restitution: 0.9 }}
+                />
+              </ground>
+              <vrExperienceHelper
+                webVROptions={{ createDeviceOrientationCamera: false }}
+                enableInteractions={true}
+              />
+            </Scene>
+          ) : null}
+        </Engine>
+      </header>
+    </div>
+  )
+}
+export default App

--- a/packages/static/content/examples/physics/index.mdx
+++ b/packages/static/content/examples/physics/index.mdx
@@ -2,6 +2,24 @@
 title: 'Physics'
 ---
 
+# Physics v2
+
+You can use the Havok plugin for physics v2
+
+When you declare your physics aggregate you need to set the type and pass in the
+appropriate options. Note the leading underscore due to how the babylon class
+was created.
+
+```jsx
+<mesh ...>
+  <physicsAggregate type={PhysicsShapeType.BOX} _options={{ mass: 0, restitution: 0.9 }} />
+</mesh>
+```
+
+[devtool:Physics2.tsx]
+
+# Physics v1
+
 You can use other supported libraries like AMMO.js - this example uses Cannon.
 
 When you declare your physics impostor you need to set the type and pass in the

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -8,6 +8,7 @@
     "@babylonjs/core": "^6.25.0",
     "@babylonjs/gui": "^6.25.0",
     "@babylonjs/gui-editor": "^6.25.0",
+    "@babylonjs/havok": "^1.2.1",
     "@babylonjs/inspector": "^6.25.0",
     "@babylonjs/loaders": "^6.25.0",
     "@babylonjs/materials": "^6.25.0",


### PR DESCRIPTION
I have used BJS 6.26.0 for `generate-code` and have physics v2 working in a small sample.

Managed to add example to the gatsby site as well on the existing Physics page (for now kept the v1 version below).