### PR TITLE
Fix: Update render to execute injectIntoDevTools once

### DIFF
--- a/packages/react-babylonjs/src/render.ts
+++ b/packages/react-babylonjs/src/render.ts
@@ -26,9 +26,24 @@ export interface ReconcilerInstance {
 
 const ReconcilerSecondary: ReconcilerType<Container, any, any, any, any> =
   Reconciler(ReactBabylonJSHostConfig)
+
+ReconcilerSecondary.injectIntoDevTools({
+  findFiberByHostInstance: (ReconcilerSecondary as any).findFiberByHostInstance,
+  bundleType: process.env.NODE_ENV === 'prod' ? 1 : 0,
+  version,
+  rendererPackageName: 'react-babylonjs',
+})
+
 const ReconcilerPrimary: ReconcilerType<Container, any, any, any, any> = Reconciler({
   ...ReactBabylonJSHostConfig,
   isPrimaryRenderer: true,
+})
+
+ReconcilerPrimary.injectIntoDevTools({
+  findFiberByHostInstance: (ReconcilerPrimary as any).findFiberByHostInstance,
+  bundleType: process.env.NODE_ENV === 'prod' ? 1 : 0,
+  version,
+  rendererPackageName: 'react-babylonjs',
 })
 
 /**
@@ -73,13 +88,6 @@ export function createReconciler(rendererOptions: RendererOptions): ReconcilerIn
         false /* hydrate */
       ) as FiberRoot
       roots.set(container, root)
-
-      reconciler.injectIntoDevTools({
-        findFiberByHostInstance: (reconciler as any).findFiberByHostInstance,
-        bundleType: process.env.NODE_ENV === 'prod' ? 1 : 0,
-        version,
-        rendererPackageName: 'react-babylonjs',
-      })
     }
 
     reconciler.updateContainer(element, root, parentComponent, callback)


### PR DESCRIPTION
This PR solves the error:
![image](https://github.com/brianzinn/react-babylonjs/assets/42896616/f072b195-2cf4-43ad-bfc6-1527236db88d)

This is reproducible when we try to unmount a Scene to generate a new component changing the key react prop:
https://codesandbox.io/p/sandbox/codesandbox-react-tsx-forked-chj46s

This fix is based on this issue:
https://github.com/pixijs/pixi-react/issues/251