### PR TITLE
Playground: jsx syntax highlighting in EditorMonaco

### DIFF
--- a/website/docs/examples/basic/moving-boxes.mdx
+++ b/website/docs/examples/basic/moving-boxes.mdx
@@ -6,6 +6,6 @@ title: 'Moving Boxes'
 
 This highlights how you can compose a scene with other React components. There
 is an example with hover/click hooks in
-Guides->[Adding more interaction and color](../../../guide/adding-interaction-and-color.mdx)
+Guides->[Adding more interaction and color](../../guide/adding-interaction-and-color.mdx)
 
 <code src="./moving-boxes/MovingBoxes.tsx" />

--- a/website/docs/guide/animation.mdx
+++ b/website/docs/guide/animation.mdx
@@ -200,5 +200,5 @@ every render in above examples.
 <code src="./animation/NoState.tsx" />
 
 There is also in
-Example->Basic->[Animations](../../examples/basic/animations.mdx) that
+Example->Basic->[Animations](../examples/basic/animations.mdx) that
 uses an Animation object that can be looped and has easing functions, etc.

--- a/website/src/plugins/pluginPlayground/web/ui/editor/EditorMonaco/EditorMonaco.tsx
+++ b/website/src/plugins/pluginPlayground/web/ui/editor/EditorMonaco/EditorMonaco.tsx
@@ -1,56 +1,52 @@
 import Editor from '@monaco-editor/react'
 import { useDark } from '@rspress/core/runtime'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useActiveCode } from '../../../hooks/useActiveCode'
 import { useLocalStorageLanguage } from '../../../hooks/useLocalStorageSettings'
 import { useQuerySnippetOnce } from '../../../hooks/useQuerySnippetOnce'
 // import { useUpdateSnippet } from '../../../hooks/useUpdateSnippet'
-import { MonacoTheme } from './constants'
+import { MonacoLanguage, MonacoTheme } from './constants'
 import styles from './EditorMonaco.module.css'
 import { initMonacoEditor } from './initMonacoEditor'
 
+if (typeof window !== 'undefined') {
+  initMonacoEditor()
+}
+
 export function EditorMonaco() {
-  const [editorReady, setEditorReady] = useState(false)
   const [loading, setLoading] = useState(false)
   const theme = useDark() ? MonacoTheme.Dark : MonacoTheme.Light
 
   const { language } = useLocalStorageLanguage()
   const { code, updateCode } = useActiveCode()
 
-  useEffect(() => {
-    initMonacoEditor().then(() => setEditorReady(true))
-  }, [])
-
   useQuerySnippetOnce(setLoading)
   // const saveToDb = useUpdateSnippet()
 
   return (
     <div className={styles.wrapper}>
-      {editorReady === true && (
-        <Editor
-          theme={theme}
-          path="App.tsx"
-          defaultLanguage="tsx"
-          value={code}
-          onChange={(code = '') => {
-            updateCode(code)
-            // saveToDb(code)
-          }}
-          language={language}
-          options={{
-            fontSize: 14,
-            lineNumbers: 'off',
-            minimap: { enabled: false },
-            quickSuggestions: true,
-            scrollBeyondLastLine: false,
-            scrollbar: {
-              verticalScrollbarSize: 8,
-              horizontalScrollbarSize: 8,
-            },
-          }}
-        />
-      )}
-      {(editorReady !== true || loading) && <div className={styles.loadingOverlay}>Loading...</div>}
+      <Editor
+        theme={theme}
+        path="App.tsx"
+        value={code}
+        onChange={(code = '') => {
+          updateCode(code)
+          // saveToDb(code)
+        }}
+        language={MonacoLanguage[language]}
+        options={{
+          fontSize: 14,
+          lineNumbers: 'off',
+          minimap: { enabled: false },
+          quickSuggestions: true,
+          scrollBeyondLastLine: false,
+          scrollbar: {
+            verticalScrollbarSize: 8,
+            horizontalScrollbarSize: 8,
+          },
+        }}
+      />
+      {loading && <div className={styles.loadingOverlay}>Loading...</div>}
     </div>
   )
 }

--- a/website/src/plugins/pluginPlayground/web/ui/editor/EditorMonaco/initMonacoEditor.ts
+++ b/website/src/plugins/pluginPlayground/web/ui/editor/EditorMonaco/initMonacoEditor.ts
@@ -1,29 +1,25 @@
 import { type Monaco, loader } from '@monaco-editor/react'
-import { shikiToMonaco } from '@shikijs/monaco'
 import typeDeclarations from '_playground_virtual_types'
 import { createHighlighter } from 'shiki'
 import { MonacoTheme } from './constants'
+import { shikiToMonaco } from './shikiToMonaco'
+
+const highlighter = await createHighlighter({
+  themes: [MonacoTheme.Dark, MonacoTheme.Light],
+  langs: ['javascript', 'typescript', 'tsx', 'jsx'],
+})
 
 const DEFAULT_MONACO_URL = 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs'
 
-export async function initMonacoEditor() {
+export function initMonacoEditor() {
   loader.config({
     paths: { vs: DEFAULT_MONACO_URL },
   })
 
-  const monaco = await loader.init()
-
-  // Register the languageIds first. Only registered languages will be highlighted.
-  monaco.languages.register({ id: 'jsx' })
-  monaco.languages.register({ id: 'tsx' })
-
-  const highlighter = await createHighlighter({
-    themes: [MonacoTheme.Dark, MonacoTheme.Light],
-    langs: ['javascript', 'typescript', 'jsx', 'tsx'],
+  loader.init().then((monaco) => {
+    shikiToMonaco(highlighter, monaco)
+    setTypescriptDefault(monaco)
   })
-
-  shikiToMonaco(highlighter, monaco)
-  setTypescriptDefault(monaco)
 }
 
 function setTypescriptDefault(monaco: Monaco) {

--- a/website/src/plugins/pluginPlayground/web/ui/editor/EditorMonaco/initMonacoEditor.ts
+++ b/website/src/plugins/pluginPlayground/web/ui/editor/EditorMonaco/initMonacoEditor.ts
@@ -18,11 +18,11 @@ export function initMonacoEditor() {
 
   loader.init().then((monaco) => {
     shikiToMonaco(highlighter, monaco)
-    setTypescriptDefault(monaco)
+    setJsTsDefaults(monaco)
   })
 }
 
-function setTypescriptDefault(monaco: Monaco) {
+function setJsTsDefaults(monaco: Monaco) {
   const ts = monaco.languages.typescript
 
   const compilerOptions = {
@@ -37,10 +37,13 @@ function setTypescriptDefault(monaco: Monaco) {
   // })
 
   ts.typescriptDefaults.setCompilerOptions(compilerOptions)
+  ts.javascriptDefaults.setCompilerOptions(compilerOptions)
+
   const dtsEntries = Object.entries(typeDeclarations)
   // ts.javascriptDefaults.setCompilerOptions(compilerOptions)
 
   for (const [path, content] of dtsEntries) {
     ts.typescriptDefaults.addExtraLib(content, `file:///${path}`)
+    ts.javascriptDefaults.addExtraLib(content, `file:///${path}`)
   }
 }

--- a/website/src/plugins/pluginPlayground/web/ui/editor/EditorMonaco/shikiToMonaco.ts
+++ b/website/src/plugins/pluginPlayground/web/ui/editor/EditorMonaco/shikiToMonaco.ts
@@ -1,0 +1,199 @@
+// Source: @shikijs/monaco
+// https://github.com/shikijs/shiki/blob/main/packages/monaco/src/index.ts
+// With a little tweak to make JSX/TSX highlighting work
+// See `tweak__matchedMonacoLanguage` below
+
+import type monacoNs from 'monaco-editor'
+import type { StateStack } from '@shikijs/vscode-textmate'
+import type { ShikiInternal, ThemeRegistrationResolved } from '@shikijs/types'
+import { EncodedTokenMetadata, INITIAL } from '@shikijs/vscode-textmate'
+
+export interface MonacoTheme extends monacoNs.editor.IStandaloneThemeData {}
+
+export interface ShikiToMonacoOptions {
+  /**
+   * The maximum length of a line to tokenize.
+   *
+   * @default 20000
+   */
+  tokenizeMaxLineLength?: number
+  /**
+   * The time limit in milliseconds for tokenizing a line.
+   *
+   * @default 500
+   */
+  tokenizeTimeLimit?: number
+}
+
+export function textmateThemeToMonacoTheme(theme: ThemeRegistrationResolved): MonacoTheme {
+  let rules = 'rules' in theme ? (theme.rules as MonacoTheme['rules']) : undefined
+
+  if (!rules) {
+    rules = []
+    const themeSettings = theme.settings || theme.tokenColors
+    for (const {
+      scope,
+      settings: { foreground, background, fontStyle },
+    } of themeSettings) {
+      const scopes = Array.isArray(scope) ? scope : [scope]
+      for (const s of scopes) {
+        if (s && (foreground || background || fontStyle)) {
+          rules.push({
+            token: s,
+            foreground: normalizeColor(foreground),
+            background: normalizeColor(background),
+            fontStyle,
+          })
+        }
+      }
+    }
+  }
+
+  const colors = Object.fromEntries(
+    Object.entries(theme.colors || {}).map(([key, value]) => [key, `#${normalizeColor(value)}`])
+  )
+
+  return {
+    base: theme.type === 'light' ? 'vs' : 'vs-dark',
+    inherit: false,
+    colors,
+    rules,
+  }
+}
+
+export function shikiToMonaco(
+  highlighter: ShikiInternal<any, any>,
+  monaco: typeof monacoNs,
+  options: ShikiToMonacoOptions = {}
+): void {
+  // Convert themes to Monaco themes and register them
+  const themeMap = new Map<string, MonacoTheme>()
+  const themeIds = highlighter.getLoadedThemes()
+  for (const themeId of themeIds) {
+    const tmTheme = highlighter.getTheme(themeId)
+    const monacoTheme = textmateThemeToMonacoTheme(tmTheme)
+    themeMap.set(themeId, monacoTheme)
+    monaco.editor.defineTheme(themeId, monacoTheme)
+  }
+
+  const colorMap: string[] = []
+  const colorToScopeMap = new Map<string, string>()
+
+  // Because Monaco does not have the API of reading the current theme,
+  // We hijack it here to keep track of the current theme.
+  const _setTheme = monaco.editor.setTheme.bind(monaco.editor)
+  monaco.editor.setTheme = (themeName: string) => {
+    const ret = highlighter.setTheme(themeName)
+    const theme = themeMap.get(themeName)
+    colorMap.length = ret.colorMap.length
+    ret.colorMap.forEach((color, i) => {
+      colorMap[i] = color
+    })
+    colorToScopeMap.clear()
+    theme?.rules.forEach((rule) => {
+      const c = normalizeColor(rule.foreground)
+      if (c && !colorToScopeMap.has(c)) colorToScopeMap.set(c, rule.token)
+    })
+    _setTheme(themeName)
+  }
+
+  // Set the first theme as the default theme
+  monaco.editor.setTheme(themeIds[0])
+
+  function findScopeByColor(color: string): string | undefined {
+    return colorToScopeMap.get(color)
+  }
+
+  // Do not attempt to tokenize if a line is too long
+  // default to 20000 (as in monaco-editor-core defaults)
+  const { tokenizeMaxLineLength = 20000, tokenizeTimeLimit = 500 } = options
+
+  const monacoLanguageIds = new Set(monaco.languages.getLanguages().map((l) => l.id))
+
+  for (const lang of highlighter.getLoadedLanguages()) {
+    /** Tweak start */
+    const tweak__matchedMonacoLanguage =
+      lang === 'jsx' ? 'javascript' : lang === 'tsx' ? 'typescript' : lang
+    if (monacoLanguageIds.has(tweak__matchedMonacoLanguage)) {
+      monaco.languages.setTokensProvider(tweak__matchedMonacoLanguage, {
+        /** Tweak end */
+        getInitialState() {
+          return new TokenizerState(INITIAL)
+        },
+        tokenize(line, state: TokenizerState) {
+          if (line.length >= tokenizeMaxLineLength) {
+            return {
+              endState: state,
+              tokens: [{ startIndex: 0, scopes: '' }],
+            }
+          }
+
+          const grammar = highlighter.getLanguage(lang)
+          const result = grammar.tokenizeLine2(line, state.ruleStack, tokenizeTimeLimit)
+
+          if (result.stoppedEarly)
+            console.warn(`Time limit reached when tokenizing line: ${line.substring(0, 100)}`)
+
+          const tokensLength = result.tokens.length / 2
+          const tokens: any[] = []
+          for (let j = 0; j < tokensLength; j++) {
+            const startIndex = result.tokens[2 * j]
+            const metadata = result.tokens[2 * j + 1]
+            const color = normalizeColor(
+              colorMap[EncodedTokenMetadata.getForeground(metadata)] || ''
+            )
+            // Because Monaco only support one scope per token,
+            // we workaround this to use color to trace back the scope
+            const scope = findScopeByColor(color) || ''
+            tokens.push({ startIndex, scopes: scope })
+          }
+
+          return { endState: new TokenizerState(result.ruleStack), tokens }
+        },
+      })
+    }
+  }
+}
+
+class TokenizerState implements monacoNs.languages.IState {
+  constructor(private _ruleStack: StateStack) {}
+
+  public get ruleStack(): StateStack {
+    return this._ruleStack
+  }
+
+  public clone(): TokenizerState {
+    return new TokenizerState(this._ruleStack)
+  }
+
+  public equals(other: monacoNs.languages.IState): boolean {
+    if (
+      !other ||
+      !(other instanceof TokenizerState) ||
+      other !== this ||
+      other._ruleStack !== this._ruleStack
+    ) {
+      return false
+    }
+
+    return true
+  }
+}
+
+function normalizeColor(color: undefined): undefined
+function normalizeColor(color: string): string
+function normalizeColor(color: string | undefined): string | undefined
+function normalizeColor(color: string | undefined): string | undefined {
+  if (!color) return color
+
+  color = (color.charCodeAt(0) === 35 ? color.slice(1) : color).toLowerCase()
+
+  // #RGB => #RRGGBB - Monaco does not support hex color with 3 or 4 digits
+  if (color.length === 3 || color.length === 4)
+    color = color
+      .split('')
+      .map((c) => c + c)
+      .join('')
+
+  return color
+}


### PR DESCRIPTION
Deployed to https://viktorzhurbin.github.io/react-babylonjs/playground

Closes #352

- Fixed jsx highlighting
- Added intellisense for JS
- fixed some broken links

Monaco treats `.jsx` within `javascript` (and `.tsx` within `typescript`) language, which shiki does not account for. It may be worth sending a PR to `@shikijs/monaco`.

You tried to register jsx/tsx as languages in Monaco, but it was bare ids, while you need to specify `extensions` and most importantly `loader`. Thus, shiki was able to do highlighting, as it knows jsx/tsx now, but Monaco had no idea how process the newly added languages. I think it makes more sense to fix the highlighter lib, rather than hijack Monaco internals.

Here's screenshots from console logging `monaco.languages.getLanguages()`: first one is its internal ts entry, second ss shows the result of `monaco.languages.register({ id: 'jsx' })` and `monaco.languages.register({ id: 'tsx' })`
<img width="376" alt="Screenshot 2025-01-20 at 13 22 15" src="https://github.com/user-attachments/assets/e8c25152-0ad4-419e-a88a-1954ff39df4c" />
<img width="235" alt="Screenshot 2025-01-20 at 13 22 36" src="https://github.com/user-attachments/assets/e37191f3-ee30-4b80-8cf5-435f7923ce06" />

I also restored the previous init logic outside the component, since when inside it was doing stuff multiple times in dev at least.