### PR TITLE
fix: :bug: fix rerendering hooks in suspense in react 19

### DIFF
--- a/packages/react-babylonjs/src/ReactBabylonJSHostConfig.ts
+++ b/packages/react-babylonjs/src/ReactBabylonJSHostConfig.ts
@@ -256,7 +256,6 @@ const ReactBabylonJSHostConfig: HostConfig<
   setCurrentUpdatePriority: (newPriority: number) => void
   onUncaughtError: (error: Error) => void
   maySuspendCommit: () => boolean
-  shouldSuspend: () => boolean
   preloadInstance: (args: any) => void
   startSuspendingCommit: () => void
   waitForCommitToBeReady: () => void
@@ -923,10 +922,6 @@ const ReactBabylonJSHostConfig: HostConfig<
   },
 
   maySuspendCommit() {
-    return false
-  },
-
-  shouldSuspend() {
     return false
   },
 

--- a/packages/react-babylonjs/src/ReactBabylonJSHostConfig.ts
+++ b/packages/react-babylonjs/src/ReactBabylonJSHostConfig.ts
@@ -923,11 +923,11 @@ const ReactBabylonJSHostConfig: HostConfig<
   },
 
   maySuspendCommit() {
-    return true
+    return false
   },
 
   shouldSuspend() {
-    return true
+    return false
   },
 
   preloadInstance(instance) {


### PR DESCRIPTION
Hi,
been a while... 
I noticed a weird behaviour on react 19, that useLayoutEffect and useImperativeHandle would update contionously even though dependencies would not change. This happened when they were wrapped with Suspense, so i.e. when using useAssetManager. 
Changing maySuspendCommit and shouldSuspend return values from true to false helped in reconciliation. Since it seems to tell the reconciler that the hooks do not need to be reevaluated. But i am not sure if it leads to other consequences.